### PR TITLE
Make sure the cycle game piece button is released before switching

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -53,6 +53,7 @@ void Robot::RobotInit()
     m_robotState = RobotState::GetInstance();
     m_robotState->Init();
 
+    m_chassis = ChassisFactory::GetChassisFactory()->GetSwerveChassis();
     m_holonomic = nullptr;
     if (m_chassis != nullptr)
     {

--- a/src/main/cpp/robotstate/RobotState.cpp
+++ b/src/main/cpp/robotstate/RobotState.cpp
@@ -40,7 +40,8 @@ RobotState *RobotState::GetInstance()
 RobotState::RobotState() : m_chassis(nullptr),
                            m_brokers(),
                            m_gamePiece(RobotStateChanges::GamePiece::Cone),
-                           m_gamePhase(RobotStateChanges::Disabled)
+                           m_gamePhase(RobotStateChanges::Disabled),
+                           m_wasReleased(true)
 {
     m_brokers.reserve(RobotStateChanges::LoopCounter);
     auto start = static_cast<int>(RobotStateChanges::DesiredGamePiece);
@@ -77,10 +78,17 @@ void RobotState::Run()
     if (DriverStation::IsTeleopEnabled())
     {
         auto controller = TeleopControl::GetInstance();
-        if (controller != nullptr && controller->IsButtonPressed(TeleopControlFunctions::CYCLE_GRABBER))
+        if (controller != nullptr)
         {
-            m_gamePiece = (m_gamePiece == RobotStateChanges::Cube) ? RobotStateChanges::Cone : RobotStateChanges::Cube;
-            PublishStateChange(RobotStateChanges::DesiredGamePiece, m_gamePiece);
+            if (controller->IsButtonPressed(TeleopControlFunctions::CYCLE_GRABBER))
+            {
+                if (m_wasReleased)
+                {
+                    m_gamePiece = (m_gamePiece == RobotStateChanges::Cube) ? RobotStateChanges::Cone : RobotStateChanges::Cube;
+                    PublishStateChange(RobotStateChanges::DesiredGamePiece, m_gamePiece);
+                }
+            }
+            m_wasReleased = !controller->IsButtonPressed(TeleopControlFunctions::CYCLE_GRABBER);
         }
     }
 }

--- a/src/main/cpp/robotstate/RobotState.h
+++ b/src/main/cpp/robotstate/RobotState.h
@@ -45,5 +45,7 @@ private:
     RobotStateChanges::GamePiece m_gamePiece;
     RobotStateChanges::GamePeriod m_gamePhase;
 
+    bool m_wasReleased;
+
     static RobotState *m_instance;
 };


### PR DESCRIPTION
Avoid the case where the button is held for more the 20 milliseconds causing it to keep switching gamepieces